### PR TITLE
fix: Correct page2

### DIFF
--- a/src/components/Page2.tsx
+++ b/src/components/Page2.tsx
@@ -48,6 +48,9 @@ function Body({ view }: Props) {
       <div className="grid grid-cols-2 gap8">
         {view.allTracks.map((track) => {
           const talk = nextTalks[track.name]
+          if (!talk) {
+            return <></>
+          }
           const speakers = view.speakersOf(talk.id)
           return (
             <Track
@@ -109,6 +112,9 @@ export function AvatarPreLoader({ view }: Props) {
     <div className="hidden">
       {view.allTracks.map((track, i) => {
         const talk = nextTalks[track.name]
+        if (!talk) {
+          return <></>
+        }
         const speakers = view.speakersOf(talk.id)
         const avatarUrl = speakers[0].avatarUrl || '/cndt2023/trademark.png'
         return <img key={i} rel="preload" src={avatarUrl} alt="for preload" />


### PR DESCRIPTION
day2の16:20-17:00のスロットだけ、表示がバグることに気づいたので直しました。
この時間枠は、BとCのtrackで17:20開始のtalkがあるのにこの枠は登壇者がいない、という特殊な状態になっています。
そのケースの考慮が漏れていました。