### PR TITLE
fix: Correct page1

### DIFF
--- a/src/components/Page1.tsx
+++ b/src/components/Page1.tsx
@@ -111,7 +111,7 @@ function Side({ view }: Props) {
           {keyNoteTalks.map((talk) => (
             <div
               key={talk.id}
-              className="text-center text-white text-sm h-[30px] font-bold"
+              className="text-center text-white text-sm h-min-[30px] font-bold"
             >
               {trim(talk.title, 80)}
             </div>


### PR DESCRIPTION
文字かぶりしないようにしました。

<img width="1500" alt="image" src="https://github.com/cloudnativedaysjp/emtec-intermission/assets/19190276/4984dd13-ee39-4480-b1a5-56e29c96995b">
