### PR TITLE
Fix: Address view issues

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -42,7 +42,7 @@ export default function Header({ view }: Props) {
         <div className="text-lg text-left">
           {getTimeStr(talk.startTime)} - {getTimeStr(talk.endTime)}
         </div>
-        <div className="text-base text-left mt-2">{trim(talk.title, 40)}</div>
+        <div className="text-base text-left mt-2">{trim(talk.title, 80)}</div>
       </div>
     </div>
   )

--- a/src/components/hooks/useGetTalksAndTracks.ts
+++ b/src/components/hooks/useGetTalksAndTracks.ts
@@ -183,9 +183,10 @@ export const useGetTracks = () => {
 export const useGetSpeakers = () => {
   const [_, setError] = useState()
 
-  const { data, isLoading, isError, error } = useGetApiV1SpeakersQuery({
-    eventAbbr: config.eventAbbr,
-  })
+  const { data, isLoading, isError, error } = useGetApiV1SpeakersQuery(
+    { eventAbbr: config.eventAbbr },
+    { pollingInterval: 300 * 1000 }
+  )
 
   useEffect(() => {
     if (isError) {


### PR DESCRIPTION
2点修正しました。

- headerの右側のtalk title、40文字制限にしていましたが、今のdesignならもっと長くても大丈夫なので、80にしました。長いものを一通りみて、画面くずれがないことを確認しています。
- speaker avatarのsigned urlのexpirationが15minなので、5minごとにspeaker情報を取り直すようにしました。垂れ流している間は基本refetchしていないですが、もしrefetchされたときに取れなくてavatarが表示されなくなるとよくないので、その予防です。