### PR TITLE
feat: Env vars from query

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,14 +1,56 @@
-const config = {
+const envVars = {
   baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL ?? '',
   eventAbbr: process.env.NEXT_PUBLIC_EVENT_ABBR ?? '',
-  transTimePage1: parseInt(process.env.NEXT_PUBLIC_TRANS_TIME_PAGE1 ?? '24'),
-  transTimePage2: parseInt(process.env.NEXT_PUBLIC_TRANS_TIME_PAGE2 ?? '24'),
-  transTimePage3: parseInt(process.env.NEXT_PUBLIC_TRANS_TIME_PAGE3 ?? '24'),
-  debug: !!process.env.NEXT_PUBLIC_DEBUG,
-  excludedTalks:
-    process.env.NEXT_PUBLIC_EXCLUDED_TALKS?.split(',').map((t) =>
-      parseInt(t)
-    ) || [],
-} as const
+  transTimePage1: process.env.NEXT_PUBLIC_TRANS_TIME_PAGE1 ?? '24',
+  transTimePage2: process.env.NEXT_PUBLIC_TRANS_TIME_PAGE2 ?? '24',
+  transTimePage3: process.env.NEXT_PUBLIC_TRANS_TIME_PAGE3 ?? '24',
+  debug: process.env.NEXT_PUBLIC_DEBUG ?? '',
+  excludedTalks: process.env.NEXT_PUBLIC_EXCLUDED_TALKS ?? ''
+}
+
+export type EnvVars = typeof envVars
+
+export type Config = {
+  baseUrl: string
+  eventAbbr: string
+  transTimePage1: number
+  transTimePage2: number
+  transTimePage3: number
+  debug: boolean
+  excludedTalks: number[]
+}
+
+const config = makeConfig(envVars) as Config
+
+function makeConfig(vars: Partial<EnvVars>): Partial<Config> {
+  const conf: Partial<Config> = {}
+  if (vars.baseUrl) {
+    conf.baseUrl = vars.baseUrl
+  }
+  if (vars.eventAbbr) {
+    conf.eventAbbr = vars.eventAbbr
+  }
+  if (vars.transTimePage1) {
+    conf.transTimePage1 = parseFloat(vars.transTimePage1)
+  }
+  if (vars.transTimePage2) {
+    conf.transTimePage2 = parseFloat(vars.transTimePage2)
+  }
+  if (vars.transTimePage3) {
+    conf.transTimePage3 = parseFloat(vars.transTimePage3)
+  }
+  if (vars.debug) {
+    conf.debug = !!vars.debug
+  }
+  if (vars.excludedTalks) {
+    conf.excludedTalks = vars.excludedTalks.split(',').map((t) => parseInt(t)) || []
+  }
+  return conf
+}
+
+
+export function extendConfig(query: Record<string, string>) {
+  Object.assign(config, makeConfig(query))
+}
 
 export default config

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ const envVars = {
   transTimePage2: process.env.NEXT_PUBLIC_TRANS_TIME_PAGE2 ?? '24',
   transTimePage3: process.env.NEXT_PUBLIC_TRANS_TIME_PAGE3 ?? '24',
   debug: process.env.NEXT_PUBLIC_DEBUG ?? '',
-  excludedTalks: process.env.NEXT_PUBLIC_EXCLUDED_TALKS ?? ''
+  excludedTalks: process.env.NEXT_PUBLIC_EXCLUDED_TALKS ?? '',
 }
 
 export type EnvVars = typeof envVars
@@ -43,11 +43,11 @@ function makeConfig(vars: Partial<EnvVars>): Partial<Config> {
     conf.debug = !!vars.debug
   }
   if (vars.excludedTalks) {
-    conf.excludedTalks = vars.excludedTalks.split(',').map((t) => parseInt(t)) || []
+    conf.excludedTalks =
+      vars.excludedTalks.split(',').map((t) => parseInt(t)) || []
   }
   return conf
 }
-
 
 export function extendConfig(query: Record<string, string>) {
   Object.assign(config, makeConfig(query))

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 const envVars = {
-  baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL ?? '',
+  apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL ?? '',
   eventAbbr: process.env.NEXT_PUBLIC_EVENT_ABBR ?? '',
   transTimePage1: process.env.NEXT_PUBLIC_TRANS_TIME_PAGE1 ?? '24',
   transTimePage2: process.env.NEXT_PUBLIC_TRANS_TIME_PAGE2 ?? '24',
@@ -11,7 +11,7 @@ const envVars = {
 export type EnvVars = typeof envVars
 
 export type Config = {
-  baseUrl: string
+  apiBaseUrl: string
   eventAbbr: string
   transTimePage1: number
   transTimePage2: number
@@ -24,8 +24,8 @@ const config = makeConfig(envVars) as Config
 
 function makeConfig(vars: Partial<EnvVars>): Partial<Config> {
   const conf: Partial<Config> = {}
-  if (vars.baseUrl) {
-    conf.baseUrl = vars.baseUrl
+  if (vars.apiBaseUrl) {
+    conf.apiBaseUrl = vars.apiBaseUrl
   }
   if (vars.eventAbbr) {
     conf.eventAbbr = vars.eventAbbr

--- a/src/pages/break/menu/[confDay].tsx
+++ b/src/pages/break/menu/[confDay].tsx
@@ -72,7 +72,6 @@ function TalkMenu({ view }: { view: Optional<MenuView> }) {
 
 function TalkMenuItem({ talk }: { talk: Optional<Talk> }) {
   const { query } = useRouter()
-  // @ts-ignore
   delete query.confDay
   if (!talk) {
     return <div />

--- a/src/pages/break/menu/[confDay].tsx
+++ b/src/pages/break/menu/[confDay].tsx
@@ -1,15 +1,19 @@
 import { useGetTalksAndTracksForMenu } from '@/components/hooks/useGetTalksAndTracks'
 import { MenuView } from '@/components/models/talkView'
-import config from '@/config'
+import config, { extendConfig } from '@/config'
 import { Talk } from '@/generated/dreamkast-api.generated'
 import { getTimeStr } from '@/utils/time'
 import { Optional } from '@/utils/types'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 
 export default function Index() {
   const router = useRouter()
   const { confDay } = router.query
+  useEffect(() => {
+    extendConfig(router.query as Record<string, string>)
+  }, [router.query])
   const { eventAbbr } = config
 
   const { isLoading, view } = useGetTalksAndTracksForMenu(

--- a/src/pages/break/menu/[confDay].tsx
+++ b/src/pages/break/menu/[confDay].tsx
@@ -71,13 +71,19 @@ function TalkMenu({ view }: { view: Optional<MenuView> }) {
 }
 
 function TalkMenuItem({ talk }: { talk: Optional<Talk> }) {
+  const { query } = useRouter()
+  // @ts-ignore
+  delete query.confDay
   if (!talk) {
     return <div />
   }
   return (
     <Link
       className="col-span-1 hover:underline"
-      href={`/break/talks/${talk.id}`}
+      href={{
+        pathname: `/break/talks/${talk.id}`,
+        query,
+      }}
     >
       <div>{talk.id}</div>
       <div>{talk.title}</div>

--- a/src/pages/break/talks/[talkId].tsx
+++ b/src/pages/break/talks/[talkId].tsx
@@ -5,13 +5,16 @@ import Page3 from '@/components/Page3'
 import Page4 from '@/components/Page4'
 import { useGetTalksAndTracks } from '@/components/hooks/useGetTalksAndTracks'
 import { PageCtx, PageCtxProvider } from '@/components/models/pageContext'
-import config from '@/config'
+import config, { extendConfig } from '@/config'
 import { useRouter } from 'next/router'
 import { useContext, useEffect } from 'react'
 
 function Pages() {
   const router = useRouter()
   const { talkId } = router.query
+  useEffect(() => {
+    extendConfig(router.query as Record<string, string>)
+  }, [router.query])
 
   const { current, setTotalPage, goNextPage } = useContext(PageCtx)
   const { isLoading, view } = useGetTalksAndTracks(talkId as string | null)

--- a/src/store/baseApi.ts
+++ b/src/store/baseApi.ts
@@ -2,6 +2,6 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import config from '@/config'
 
 export const baseApi = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: config.baseUrl }),
+  baseQuery: fetchBaseQuery({ baseUrl: config.apiBaseUrl }),
   endpoints: () => ({}),
 })


### PR DESCRIPTION
環境変数で指定している値を、全てquery stringからoverrideできるようにしました。
NEXT_PUBLIC_XXX となっている場合、XXXの部分をcamelCaseにしてqueryに追加してもらえたら、overrideできます。
debugだけではなく、excludedTalks や transTimePageX の差し替えなどもできます。

CNDT2023で必須の修正ではないと思うので、カンファレンスが終わった後でmergeでも良さそうです。