### PR TITLE
feat: Add button to update video cache

### DIFF
--- a/src/pages/break/talks/[talkId].tsx
+++ b/src/pages/break/talks/[talkId].tsx
@@ -9,6 +9,12 @@ import config, { extendConfig } from '@/config'
 import { useRouter } from 'next/router'
 import { useContext, useEffect } from 'react'
 
+function updateCache() {
+  if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({ type: 'UPDATE_CACHE' })
+  }
+}
+
 function Pages() {
   const router = useRouter()
   const { talkId } = router.query
@@ -43,6 +49,12 @@ function Pages() {
       </div>
       {config.debug && (
         <>
+          <button
+            onClick={updateCache}
+            className="font-bold py-0 px-4 mx-2 my-2 rounded bg-yellow-300 items-right"
+          >
+            Update Video Cache
+          </button>
           <button
             onClick={goNextPage}
             className="font-bold py-0 px-4 mx-2 my-2 rounded bg-blue-300 items-right"


### PR DESCRIPTION
debugモードにボタンを追加しました。
このボタンを押すと、service-workerのvideo cacheを更新できます。

<img width="698" alt="image" src="https://github.com/cloudnativedaysjp/emtec-intermission/assets/19190276/b26d8e95-4ebb-4691-b5b5-37103f8da253">

また、手動更新機能を追加したので、cacheがないときにstreamingと並行してcacheを作る、という処理をしていたのを消しました。
この機能は、ちゃんと実装できていなくてcacheはするもののstreamingが動かない状態でした。消したことで、仮にcacheがない場合はバグることなく素直にstreamingだけを行うようになっています。